### PR TITLE
docs(back): documenta contrato da API com OpenAPI/Swagger

### DIFF
--- a/backend/src/main/java/br/com/accessmap/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/br/com/accessmap/backend/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package br.com.accessmap.backend.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI accessMapOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("AccessMap API")
+                        .description("API da plataforma colaborativa de avaliação de acessibilidade de "
+                                + "estabelecimentos: cadastro de usuários, cache de locais (Google Place ID) "
+                                + "e avaliações de acessibilidade com sistema de confiabilidade.")
+                        .version("v0.1")
+                        .contact(new Contact().name("Equipe AccessMap")));
+    }
+}

--- a/backend/src/main/java/br/com/accessmap/backend/identity/controller/UserController.java
+++ b/backend/src/main/java/br/com/accessmap/backend/identity/controller/UserController.java
@@ -3,6 +3,11 @@ package br.com.accessmap.backend.identity.controller;
 import br.com.accessmap.backend.identity.dto.UserRequestDto;
 import br.com.accessmap.backend.identity.model.User;
 import br.com.accessmap.backend.identity.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -12,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
+@Tag(name = "Usuários", description = "Cadastro e gerenciamento de contas de usuário")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -19,28 +25,50 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "Lista todos os usuários cadastrados")
     @GetMapping
     public ResponseEntity<List<User>> listAll() {
         return ResponseEntity.ok(userService.findAll());
     }
 
+    @Operation(summary = "Busca um usuário pelo ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Usuário encontrado"),
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<User> getById(@PathVariable String id) {
+    public ResponseEntity<User> getById(@Parameter(description = "ID do usuário") @PathVariable String id) {
         return ResponseEntity.ok(userService.findById(id));
     }
 
+    @Operation(summary = "Cadastra um novo usuário")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Usuário criado"),
+            @ApiResponse(responseCode = "400", description = "Campo obrigatório ausente, inválido ou e-mail já em uso")
+    })
     @PostMapping
     public ResponseEntity<User> create(@Valid @RequestBody UserRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.create(request));
     }
 
+    @Operation(summary = "Atualiza parcialmente os dados de um usuário")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Usuário atualizado"),
+            @ApiResponse(responseCode = "400", description = "E-mail já em uso por outro usuário"),
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
     @PatchMapping("/{id}")
     public ResponseEntity<User> update(@Valid @PathVariable String id, @RequestBody UserRequestDto request) {
         return ResponseEntity.ok(userService.update(id, request));
     }
 
+    @Operation(summary = "Remove um usuário")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Usuário removido"),
+            @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+    })
     @DeleteMapping("/{id}")
-    public ResponseEntity<Map<String, String>> delete(@PathVariable String id) {
+    public ResponseEntity<Map<String, String>> delete(@Parameter(description = "ID do usuário") @PathVariable String id) {
         userService.delete(id);
         return ResponseEntity.ok(Map.of("message", "Usuário removido com sucesso"));
     }

--- a/backend/src/main/java/br/com/accessmap/backend/place/controller/PlaceController.java
+++ b/backend/src/main/java/br/com/accessmap/backend/place/controller/PlaceController.java
@@ -2,6 +2,11 @@ package br.com.accessmap.backend.place.controller;
 
 import br.com.accessmap.backend.place.model.Place;
 import br.com.accessmap.backend.place.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Locais", description = "Consulta de locais avaliados: cache de agregados sobre o Google Place ID")
 @RestController
 @RequestMapping("/api/places")
 @RequiredArgsConstructor
@@ -16,8 +22,14 @@ public class PlaceController {
 
     private final PlaceService placeService;
 
+    @Operation(summary = "Busca um local pelo Google Place ID, com a nota média e o total de avaliações")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Local encontrado"),
+            @ApiResponse(responseCode = "404", description = "Nenhuma avaliação registrada para esse Place ID ainda")
+    })
     @GetMapping("/{placeId}")
-    public ResponseEntity<Place> getByPlaceId(@PathVariable String placeId) {
+    public ResponseEntity<Place> getByPlaceId(
+            @Parameter(description = "Place ID do Google Maps Platform") @PathVariable String placeId) {
         return ResponseEntity.ok(placeService.findByPlaceId(placeId));
     }
 }

--- a/backend/src/main/java/br/com/accessmap/backend/review/controller/ReviewController.java
+++ b/backend/src/main/java/br/com/accessmap/backend/review/controller/ReviewController.java
@@ -3,6 +3,11 @@ package br.com.accessmap.backend.review.controller;
 import br.com.accessmap.backend.review.dto.ReviewRequestDto;
 import br.com.accessmap.backend.review.model.Review;
 import br.com.accessmap.backend.review.service.ReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -11,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Avaliações", description = "Criação e consulta de avaliações de acessibilidade")
 @RestController
 @RequestMapping("/api/reviews")
 @RequiredArgsConstructor
@@ -18,16 +24,29 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @Operation(summary = "Lista as avaliações de um local")
     @GetMapping
-    public ResponseEntity<List<Review>> listByPlace(@RequestParam String placeId) {
+    public ResponseEntity<List<Review>> listByPlace(
+            @Parameter(description = "Place ID do Google Maps Platform") @RequestParam String placeId) {
         return ResponseEntity.ok(reviewService.findByPlaceId(placeId));
     }
 
+    @Operation(summary = "Busca uma avaliação pelo ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Avaliação encontrada"),
+            @ApiResponse(responseCode = "404", description = "Avaliação não encontrada")
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<Review> getById(@PathVariable String id) {
+    public ResponseEntity<Review> getById(@Parameter(description = "ID da avaliação") @PathVariable String id) {
         return ResponseEntity.ok(reviewService.findById(id));
     }
 
+    @Operation(summary = "Cria uma nova avaliação de acessibilidade para um local")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Avaliação criada"),
+            @ApiResponse(responseCode = "400", description = "Campo obrigatório ausente ou nota fora do intervalo 1-5"),
+            @ApiResponse(responseCode = "404", description = "Usuário informado não existe")
+    })
     @PostMapping
     public ResponseEntity<Review> create(@Valid @RequestBody ReviewRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(reviewService.create(request));


### PR DESCRIPTION
## O que este PR resolve?

Resolve #22 — documentação do contrato da API via Swagger/OpenAPI. O `springdoc-openapi-starter-webmvc-ui` já estava no `pom.xml`, mas sem nenhuma anotação além do default, então o `/swagger-ui.html` não tinha descrição nenhuma dos endpoints.

## O que foi feito

- `config/OpenApiConfig.java`: metadados gerais da API (título, descrição, versão)
- `@Tag` em cada controller (Usuários, Locais, Avaliações), agrupando os endpoints na UI
- `@Operation` com resumo em cada endpoint
- `@ApiResponses` documentando os códigos de retorno reais (200/201/400/404), de acordo com o que o `ApiExceptionHandler` já devolve
- `@Parameter` explicando que `placeId` é o Place ID do Google Maps Platform, não um ID interno

## Quais endpoints foram alterados?

Nenhum contrato mudou — só anotações de documentação em cima dos endpoints existentes de `/api/users`, `/api/places` e `/api/reviews`.

## Como testar

```bash
./mvnw spring-boot:run
```
Acessar `http://localhost:8080/swagger-ui.html` e conferir que os três grupos (Usuários, Locais, Avaliações) aparecem com descrições.

## Test plan

- [x] `./mvnw test` — 26 testes unitários passando
- [ ] Conferir visualmente o `/swagger-ui.html` depois do merge (não validei rodando localmente, Postgres não estava disponível)